### PR TITLE
Myer/django upgrade 1.11

### DIFF
--- a/tastypie_mongoengine/fields.py
+++ b/tastypie_mongoengine/fields.py
@@ -175,7 +175,7 @@ class EmbeddedListField(BuildRelatedMixin, fields.ToManyField):
             return data
 
         data['embedded'].update({
-            'resource_types': type_map.keys(),
+            'resource_types': list(type_map.keys()),
         })
 
         return data
@@ -185,7 +185,7 @@ class EmbeddedListField(BuildRelatedMixin, fields.ToManyField):
 
         the_m2ms = None
 
-        if isinstance(self.attribute, basestring):
+        if isinstance(self.attribute, str):
             the_m2ms = getattr(bundle.obj, self.attribute)
         elif callable(self.attribute):
             the_m2ms = self.attribute(bundle)
@@ -275,7 +275,7 @@ class ReferencedListField(TastypieMongoengineMixin, fields.ToManyField):
 
         the_m2ms = None
 
-        if isinstance(self.attribute, basestring):
+        if isinstance(self.attribute, str):
             the_m2ms = getattr(bundle.obj, self.attribute)
         elif callable(self.attribute):
             the_m2ms = self.attribute(bundle)
@@ -304,7 +304,7 @@ class ReferencedListField(TastypieMongoengineMixin, fields.ToManyField):
         # We are ignoring any extra fields not present in resource
         # We delete them because otherwise resource_from_data fail
         # when using getattr and they are missing in resource
-        for k in data.keys():
+        for k in list(data.keys()):
             if not hasattr(fk_resource, k):
                 del data[k]
 

--- a/tastypie_mongoengine/fields.py
+++ b/tastypie_mongoengine/fields.py
@@ -211,10 +211,7 @@ class EmbeddedListField(BuildRelatedMixin, fields.ToManyField):
 
             m2m_bundle = tastypie_bundle.Bundle(obj=m2m, request=bundle.request)
             self.m2m_resources.append(m2m_resource)
-            if tastypie.__version__ >= (0, 9, 15):
-                m2m_dehydrated.append(self.dehydrate_related(m2m_bundle, m2m_resource, for_list=for_list))
-            else:
-                m2m_dehydrated.append(self.dehydrate_related(m2m_bundle, m2m_resource))
+            m2m_dehydrated.append(self.dehydrate_related(m2m_bundle, m2m_resource))
 
         return m2m_dehydrated
 
@@ -293,10 +290,7 @@ class ReferencedListField(TastypieMongoengineMixin, fields.ToManyField):
             m2m_resource = self.get_related_resource(m2m)
             m2m_bundle = tastypie_bundle.Bundle(obj=m2m, request=bundle.request)
             self.m2m_resources.append(m2m_resource)
-            if tastypie.__version__ >= (0, 9, 15):
-                m2m_dehydrated.append(self.dehydrate_related(m2m_bundle, m2m_resource, for_list=for_list))
-            else:
-                m2m_dehydrated.append(self.dehydrate_related(m2m_bundle, m2m_resource))
+            m2m_dehydrated.append(self.dehydrate_related(m2m_bundle, m2m_resource))
 
         return m2m_dehydrated
 

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -3,7 +3,7 @@ import re
 import sys
 
 from django.conf import urls
-from django.core import exceptions, urlresolvers
+from django.urls import exceptions, urlresolvers
 from django.db.models import base as models_base
 # from django.utils import datastructures
 from collections import OrderedDict

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -72,20 +72,20 @@ class ListQuerySet(OrderedDict):
 
         # pk optimization
         if 'pk' in kwargs:
-            pk = unicode(self._process_filter_value(kwargs.pop('pk')))
+            pk = str(self._process_filter_value(kwargs.pop('pk')))
             if pk in result:
-                result = ListQuerySet([(unicode(pk), result[pk])])
+                result = ListQuerySet([(str(pk), result[pk])])
             # Sometimes None is passed as a pk to not filter by pk
             elif pk is not None:
                 result = ListQuerySet()
 
-        for field, value in kwargs.iteritems():
+        for field, value in kwargs.items():
             value = self._process_filter_value(value)
             if constants.LOOKUP_SEP in field:
                 raise tastypie_exceptions.InvalidFilterError("Unsupported filter: (%s, %s)" % (field, value))
 
             try:
-                result = ListQuerySet([(unicode(obj.pk), obj) for obj in result.itervalues() if getattr(obj, field) == value])
+                result = ListQuerySet([(str(obj.pk), obj) for obj in result.values() if getattr(obj, field) == value])
             except AttributeError as ex:
                 raise tastypie_exceptions.InvalidFilterError(ex)
 
@@ -123,14 +123,14 @@ class ListQuerySet(OrderedDict):
                 reverse = False
 
             try:
-                result = [(unicode(obj.pk), obj) for obj in sorted(result, key=self.attrgetter(field), reverse=reverse)]
+                result = [(str(obj.pk), obj) for obj in sorted(result, key=self.attrgetter(field), reverse=reverse)]
             except (AttributeError, IndexError) as ex:
                 raise tastypie_exceptions.InvalidSortError(ex)
 
         return ListQuerySet(result)
 
     def __iter__(self):
-        return self.itervalues()
+        return iter(self.values())
 
     def __reversed__(self):
         for key in reversed(self.keyOrder):
@@ -139,15 +139,15 @@ class ListQuerySet(OrderedDict):
     def __getitem__(self, key):
         # Tastypie access object_list[0], so we pretend to be
         # a list here (order is same as our iteration order)
-        if isinstance(key, (int, long)):
-            return itertools.islice(self, key, key + 1).next()
+        if isinstance(key, int):
+            return next(itertools.islice(self, key, key + 1))
         # Tastypie also access sliced object_list in paginator
         elif isinstance(key, slice):
             return itertools.islice(self, key.start, key.stop, key.step)
         else:
             # We could convert silently to unicode here, but it is
             # better to check to find possible errors in program logic
-            assert isinstance(key, unicode), key
+            assert isinstance(key, str), key
             return super(ListQuerySet, self).__getitem__(key)
 
 
@@ -159,14 +159,14 @@ def trim(docstring):
     # and split into a list of lines:
     lines = docstring.expandtabs().splitlines()
     # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxint
+    indent = sys.maxsize
     for line in lines[1:]:
         stripped = line.lstrip()
         if stripped:
             indent = min(indent, len(line) - len(stripped))
     # Remove indentation (first line is special):
     trimmed = [lines[0].strip()]
-    if indent < sys.maxint:
+    if indent < sys.maxsize:
         for line in lines[1:]:
             trimmed.append(line[indent:].rstrip())
     # Strip off trailing and leading blank lines:
@@ -205,7 +205,7 @@ class MongoEngineModelDeclarativeMetaclass(resources.ModelDeclarativeMetaclass):
         include_fields = getattr(new_class._meta, 'fields', [])
         excludes = getattr(new_class._meta, 'excludes', [])
 
-        field_names = new_class.base_fields.keys()
+        field_names = list(new_class.base_fields.keys())
 
         for field_name in field_names:
             if field_name == 'resource_uri':
@@ -242,7 +242,7 @@ class MongoEngineModelDeclarativeMetaclass(resources.ModelDeclarativeMetaclass):
             del(new_class.base_fields['resource_type'])
 
         seen_types = set()
-        for typ, resource in type_map.iteritems():
+        for typ, resource in type_map.items():
             if resource == 'self':
                 type_map[typ] = new_class
                 break
@@ -271,12 +271,10 @@ class MongoEngineModelDeclarativeMetaclass(resources.ModelDeclarativeMetaclass):
         return new_class
 
 
-class MongoEngineResource(resources.ModelResource):
+class MongoEngineResource(resources.ModelResource, metaclass=MongoEngineModelDeclarativeMetaclass):
     """
     Adaptation of ``ModelResource`` to MongoEngine.
     """
-
-    __metaclass__ = MongoEngineModelDeclarativeMetaclass
 
     def get_via_uri(self, uri, request=None):
         """
@@ -293,14 +291,14 @@ class MongoEngineResource(resources.ModelResource):
         except (NotFound, Resolver404):
             # if this is a polymorphic resource check the uri against the resources in self._meta.polymorphic
             type_map = getattr(self._meta, 'polymorphic', {})
-            for type_, resource in type_map.iteritems():
+            for type_, resource in type_map.items():
                 try:
                     return resource().get_via_uri(uri, request)
                 except (NotFound, Resolver404):
                     pass
             # the uri wasn't found at any of the polymorphic resources, it is an incorrect URI for this resource
             raise
-        except Exception, e:
+        except Exception as e:
             raise e
 
     # Data preparation.
@@ -314,7 +312,7 @@ class MongoEngineResource(resources.ModelResource):
         base = super(MongoEngineResource, self).base_urls()
 
         embedded_urls = []
-        embedded = (name for name, obj in self.fields.iteritems() if isinstance(obj, tastypie_mongoengine_fields.EmbeddedListField))
+        embedded = (name for name, obj in self.fields.items() if isinstance(obj, tastypie_mongoengine_fields.EmbeddedListField))
 
         for name in embedded:
             embedded_urls.extend((
@@ -436,7 +434,7 @@ class MongoEngineResource(resources.ModelResource):
         return self._wrap_request(request, lambda: super(MongoEngineResource, self).get_schema(request, **kwargs))
 
     def _get_resource_from_class(self, type_map, cls):
-        for resource in type_map.itervalues():
+        for resource in type_map.values():
             if resource._meta.object_class is cls:
                 return resource
         raise KeyError(cls)
@@ -446,7 +444,7 @@ class MongoEngineResource(resources.ModelResource):
         # that we do not miss real match, so if self._meta.object_class
         # matches, we still check other items, otherwise we return immediately
         res = None
-        for typ, resource in type_map.iteritems():
+        for typ, resource in type_map.items():
             if resource._meta.object_class is cls:
                 if resource._meta.object_class is self._meta.object_class:
                     res = typ
@@ -488,7 +486,7 @@ class MongoEngineResource(resources.ModelResource):
         # We redo check for required fields as Tastypie is not
         # reliable as it does checks in an inconsistent way
         # (https://github.com/toastdriven/django-tastypie/issues/491)
-        for field_object in self.fields.itervalues():
+        for field_object in self.fields.values():
             if field_object.readonly or getattr(field_object, '_primary_key', False):
                 continue
 
@@ -537,7 +535,7 @@ class MongoEngineResource(resources.ModelResource):
     def build_schema(self):
         data = super(MongoEngineResource, self).build_schema()
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             # We process ListField specially here (and not use field's
             # build_schema) so that Tastypie's ListField can be used
             if isinstance(field_object, tastypie_fields.ListField):
@@ -560,7 +558,7 @@ class MongoEngineResource(resources.ModelResource):
             return data
 
         data.update({
-            'resource_types': type_map.keys(),
+            'resource_types': list(type_map.keys()),
         })
 
         return data
@@ -614,7 +612,7 @@ class MongoEngineResource(resources.ModelResource):
             raise tastypie_exceptions.NotFound("A document instance matching the provided arguments could not be found.")
 
     def create_identifier(self, obj):
-        return unicode(obj.pk)
+        return str(obj.pk)
 
     def save(self, bundle, skip_errors=False):
         try:
@@ -626,7 +624,7 @@ class MongoEngineResource(resources.ModelResource):
         # Our related documents are not stored in a queryset, but a list,
         # so we have to manually build a list, set it, and save
 
-        for field_name, field_object in self.fields.items():
+        for field_name, field_object in list(self.fields.items()):
             if not getattr(field_object, 'is_m2m', False):
                 continue
 
@@ -700,7 +698,7 @@ class MongoEngineResource(resources.ModelResource):
         if not cls._meta.object_class:
             return final_fields
 
-        for name, f in cls._meta.object_class._fields.iteritems():
+        for name, f in cls._meta.object_class._fields.items():
             # If the field name is already present, skip
             if name in cls.base_fields:
                 continue
@@ -793,7 +791,7 @@ class MongoEngineListResource(MongoEngineResource):
         self.parent = self._parent(api_name)
 
         # Validate the fields and set primary key if needed
-        for field_name, field in self._meta.object_class._fields.iteritems():
+        for field_name, field in self._meta.object_class._fields.items():
             if field.primary_key:
                 # Ensure only one primary key is set
                 current_pk = getattr(self._meta, 'id_field', None)
@@ -845,7 +843,7 @@ class MongoEngineListResource(MongoEngineResource):
             for obj in getattr(self.instance, self.attribute):
                 pk = getattr(obj, pk_field)
                 obj.__class__.pk = tastypie_mongoengine_fields.link_property(pk_field)
-                object_list.append((unicode(pk), obj))
+                object_list.append((str(pk), obj))
             return ListQuerySet(object_list)
 
         else:
@@ -853,13 +851,13 @@ class MongoEngineListResource(MongoEngineResource):
                 obj.pk = index
                 return obj
 
-            return ListQuerySet([(unicode(index), add_index(index, obj)) for index, obj in enumerate(getattr(self.instance, self.attribute))])
+            return ListQuerySet([(str(index), add_index(index, obj)) for index, obj in enumerate(getattr(self.instance, self.attribute))])
 
     def obj_create(self, bundle, **kwargs):
         try:
             bundle.obj = self._meta.object_class()
 
-            for key, value in kwargs.items():
+            for key, value in list(kwargs.items()):
                 setattr(bundle.obj, key, value)
 
             bundle = self.full_hydrate(bundle)
@@ -940,7 +938,7 @@ class MongoEngineListResource(MongoEngineResource):
             object_list.pop(self.find_embedded_document(object_list, pk_field, obj.pk))
 
         # Make sure to delete FileField files
-        for fieldname, field in obj._fields.items():
+        for fieldname, field in list(obj._fields.items()):
             if isinstance(field, mongoengine_fields.FileField):
                 obj[fieldname].delete()
 

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -219,9 +219,10 @@ class MongoEngineModelDeclarativeMetaclass(resources.ModelDeclarativeMetaclass):
                     del(new_class.base_fields[field_name])
             if field_name in new_class.declared_fields:
                 continue
-            if len(include_fields) and field_name not in include_fields:
+            # Meta.fields is None by default
+            if include_fields and field_name not in include_fields:
                 del(new_class.base_fields[field_name])
-            if len(excludes) and field_name in excludes:
+            if excludes and field_name in excludes:
                 del(new_class.base_fields[field_name])
 
         # Add in the new fields
@@ -711,9 +712,9 @@ class MongoEngineResource(resources.ModelResource, metaclass=MongoEngineModelDec
             if excludes and name in excludes:
                 continue
 
-            # TODO: Might need it in the future
-            # if cls.should_skip_field(f):
-            #     continue
+            # remove _cls
+            if name == '_cls':
+                continue
 
             api_field_class = cls.api_field_from_mongo_field(f)
 

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -3,7 +3,7 @@ import re
 import sys
 
 from django.conf import urls
-from django.urls import exceptions, urlresolvers
+from django.core import exceptions, urlresolvers
 from django.db.models import base as models_base
 # from django.utils import datastructures
 from collections import OrderedDict

--- a/tastypie_mongoengine/test_runner.py
+++ b/tastypie_mongoengine/test_runner.py
@@ -1,4 +1,4 @@
-import urlparse
+import urllib.parse
 
 from django.conf import settings
 from django.test import client, simple, testcases
@@ -82,7 +82,7 @@ def requestfactory_patch(self, path, data=None, content_type=client.MULTIPART_CO
     data = data or {}
     patch_data = self._encode_data(data, content_type)
 
-    parsed = urlparse.urlparse(path)
+    parsed = urllib.parse.urlparse(path)
     request = {
         'CONTENT_LENGTH': len(patch_data),
         'CONTENT_TYPE': content_type,


### PR DESCRIPTION
Solves this upon running tests:
```
    from tastypie_mongoengine.resources import MongoEngineResource
  File "/home/ubuntu/hbx/python/src/django-tastypie-mongoengine/tastypie_mongoengine/resources.py", line 274, in <module>
    class MongoEngineResource(resources.ModelResource, metaclass=MongoEngineModelDeclarativeMetaclass):
  File "/home/ubuntu/hbx/python/src/django-tastypie-mongoengine/tastypie_mongoengine/resources.py", line 222, in __new__
    if len(include_fields) and field_name not in include_fields:
TypeError: object of type 'NoneType' has no len()

```